### PR TITLE
Remove __del__ function

### DIFF
--- a/youtube_upload/client.py
+++ b/youtube_upload/client.py
@@ -87,9 +87,6 @@ class YoutubeUploader():
 
         self.max_retry = MAX_RETRIES
 
-    def __del__(self):
-        self.close()
-
     # This is if you have another OAuth file to use
     def authenticate(
             self,


### PR DESCRIPTION
Remove `__del__` function to keep oauth.json after the end program, user can use close function to delete this file.

Signed-off-by: Bensuperpc <bensuperpc@gmail.com>